### PR TITLE
Add monitor command

### DIFF
--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -109,8 +109,12 @@ def transcrypt_sketch(sketch_name, sketch_dir):
         cprint.err(f"Error with transcrypt: the {__target} directory wasn't created.", interrupt=True)
 
     target_dir = sketch_dir.child(TARGET_DIRNAME)
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
     shutil.move(__target, target_dir)
 
+    index_file = sketch_dir.child("index.html")
+    cprint.ok(f"Your sketch is ready and available at {index_file}")
 
 if __name__ == "__main__":
     command_line_entrypoint()

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -35,9 +35,9 @@ def configure_new_sketch(sketch_name, sketch_dir):
     - sketch_name: name of the sketch (will create a {sketch_name}.py)
 
     Opitionals
-    - sketch_dir: directory to save the sketch (defaults to ./{sketch_name})
+    - sketch_dir: directory to save the sketch (defaults to {sketch_name})
     """
-    SKETCH_DIR = Path(sketch_dir or f'./{sketch_name}')
+    SKETCH_DIR = Path(sketch_dir or f'{sketch_name}')
 
     if SKETCH_DIR.exists():
         cprint.warn(f"Cannot configure a new sketch.")
@@ -67,7 +67,7 @@ def configure_new_sketch(sketch_name, sketch_dir):
 
 
 def _validate_sketch_paths(sketch_name=None, sketch_dir=None):
-    sketch_dir = Path(sketch_dir or f'./{sketch_name}')
+    sketch_dir = Path(sketch_dir or f'{sketch_name}')
 
     sketch = sketch_dir.child(f"{sketch_name}.py")
     if not sketch.exists():
@@ -90,10 +90,10 @@ def transcrypt_sketch(sketch_name, sketch_dir):
     Command to generate the P5.js code for a python sketch
 
     Params:
-    - sketch_name: name of the sketch (will create a {sketch_name}.py)
+    - sketch_name: name of the sketch
 
     Opitionals
-    - sketch_dir: sketch's directory (defaults to ./{sketch_name})
+    - sketch_dir: sketch's directory (defaults to {sketch_name})
     """
     sketch_dir, sketch = _validate_sketch_paths(sketch_name, sketch_dir)
 

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -49,7 +49,7 @@ def transcrypt_sketch(sketch_name, sketch_dir):
     cprint.ok(f"Your sketch is ready and available at {index_file}")
 
 
-@command_line_entrypoint.command("monitor_sketch")
+@command_line_entrypoint.command("monitor")
 @click.argument("sketch_name")
 @click.option('--sketch_dir', '-d', default=None)
 def monitor_sketch(sketch_name, sketch_dir):
@@ -63,10 +63,7 @@ def monitor_sketch(sketch_name, sketch_dir):
     Opitionals
     - sketch_dir: sketch's directory (defaults to ./{sketch_name})
     """
-    sketch_dir, sketch = _validate_sketch_paths(sketch_name, sketch_dir)
-
-    print("command")
-
+    commands.monitor_sketch(sketch_name, sketch_dir)
 
 if __name__ == "__main__":
     command_line_entrypoint()

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -65,6 +65,11 @@ def configure_new_sketch(sketch_name, sketch_dir):
     with open(SKETCH_DIR.child("index.html"), "w") as fd:
         fd.write(index_contet)
 
+    sketch_py = templates_files[0][1]
+    cprint.ok(f"Your sketch was created!")
+    cprint.ok(f"Please, open and edit the file {sketch_py} to draw. When you're ready to see your results, just run:")
+    cprint.ok(f"\t pytop5js transcrypt {sketch_name}")
+
 
 def _validate_sketch_paths(sketch_name=None, sketch_dir=None):
     sketch_dir = Path(sketch_dir or f'{sketch_name}')
@@ -100,9 +105,10 @@ def transcrypt_sketch(sketch_name, sketch_dir):
     command = ' '.join([str(c) for c in [
         'transcrypt', '-xp', PYP5_DIR, '-b', '-m', '-n', sketch
     ]])
-    cprint.info(f"Command:\n\t {command}")
+    cprint.info(f"Converting Python to P5.js...\nRunning command:\n\t {command}")
 
-    subprocess.check_output(shlex.split(command))
+    proc = subprocess.Popen(shlex.split(command))
+    proc.wait()
 
     __target = sketch_dir.child('__target__')
     if not __target.exists():

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -1,20 +1,8 @@
 #!/usr/bin/env python3
-import click
-import os
-import subprocess
-import shlex
-import random
-from datetime import date
 from cprint import cprint
-import shutil
-from unipath import Path
-from jinja2 import Environment, FileSystemLoader
+import click
 
-
-PYP5_DIR = Path(__file__).parent
-TEMPLATES_DIR = PYP5_DIR.child('templates')
-TARGET_DIRNAME = "target"
-templates = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+import commands
 
 @click.group()
 def command_line_entrypoint():
@@ -37,54 +25,11 @@ def configure_new_sketch(sketch_name, sketch_dir):
     Opitionals
     - sketch_dir: directory to save the sketch (defaults to {sketch_name})
     """
-    SKETCH_DIR = Path(sketch_dir or f'{sketch_name}')
+    sketch_py = commands.new_sketch(sketch_name, sketch_dir)
 
-    if SKETCH_DIR.exists():
-        cprint.warn(f"Cannot configure a new sketch.")
-        cprint.err(f"The directory {SKETCH_DIR} already exists.", interrupt=True)
-
-    static_dir = SKETCH_DIR.child('static')
-    templates_files = [
-        (TEMPLATES_DIR.child('base_sketch.py'), SKETCH_DIR.child(f'{sketch_name}.py')),
-        (PYP5_DIR.child('static', 'p5.js'), static_dir.child('p5.js'))
-    ]
-
-    index_template = templates.get_template('index.html')
-    context = {
-        "p5_js_url": "static/p5.js",
-        "sketch_js_url": f"{TARGET_DIRNAME}/{sketch_name}.js",
-        "sketch_name": sketch_name,
-    }
-    index_contet = index_template.render(context)
-
-    os.mkdir(SKETCH_DIR)
-    os.mkdir(static_dir)
-    for src, dest in templates_files:
-        shutil.copyfile(src, dest)
-
-    with open(SKETCH_DIR.child("index.html"), "w") as fd:
-        fd.write(index_contet)
-
-    sketch_py = templates_files[0][1]
     cprint.ok(f"Your sketch was created!")
     cprint.ok(f"Please, open and edit the file {sketch_py} to draw. When you're ready to see your results, just run:")
     cprint.ok(f"\t pytop5js transcrypt {sketch_name}")
-
-
-def _validate_sketch_paths(sketch_name=None, sketch_dir=None):
-    sketch_dir = Path(sketch_dir or f'{sketch_name}')
-
-    sketch = sketch_dir.child(f"{sketch_name}.py")
-    if not sketch.exists():
-        sketch_file = Path(os.getcwd()).child(f"{sketch_name}.py")
-        if not sketch_file.exists():
-            cprint.warn(f"Couldn't find the sketch.")
-            cprint.err(f"Neither the file {sketch} or {sketch_file} exist.", interrupt=True)
-
-        sketch = sketch_file
-        sketch_dir = sketch.parent
-
-    return sketch_dir, sketch
 
 
 @command_line_entrypoint.command("transcrypt")
@@ -100,27 +45,28 @@ def transcrypt_sketch(sketch_name, sketch_dir):
     Opitionals
     - sketch_dir: sketch's directory (defaults to {sketch_name})
     """
+    index_file = commands.transcrypt_sketch(sketch_name, sketch_dir)
+    cprint.ok(f"Your sketch is ready and available at {index_file}")
+
+
+@command_line_entrypoint.command("monitor_sketch")
+@click.argument("sketch_name")
+@click.option('--sketch_dir', '-d', default=None)
+def monitor_sketch(sketch_name, sketch_dir):
+    """
+    Command to generate keep watching a sketch's dir and, after any change,
+    it'll automatically generate the JS files as in pytop5js transcrypt command
+
+    Params:
+    - sketch_name: name of the sketch
+
+    Opitionals
+    - sketch_dir: sketch's directory (defaults to ./{sketch_name})
+    """
     sketch_dir, sketch = _validate_sketch_paths(sketch_name, sketch_dir)
 
-    command = ' '.join([str(c) for c in [
-        'transcrypt', '-xp', PYP5_DIR, '-b', '-m', '-n', sketch
-    ]])
-    cprint.info(f"Converting Python to P5.js...\nRunning command:\n\t {command}")
+    print("command")
 
-    proc = subprocess.Popen(shlex.split(command))
-    proc.wait()
-
-    __target = sketch_dir.child('__target__')
-    if not __target.exists():
-        cprint.err(f"Error with transcrypt: the {__target} directory wasn't created.", interrupt=True)
-
-    target_dir = sketch_dir.child(TARGET_DIRNAME)
-    if target_dir.exists():
-        shutil.rmtree(target_dir)
-    shutil.move(__target, target_dir)
-
-    index_file = sketch_dir.child("index.html")
-    cprint.ok(f"Your sketch is ready and available at {index_file}")
 
 if __name__ == "__main__":
     command_line_entrypoint()

--- a/pyp5js/commands.py
+++ b/pyp5js/commands.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import shlex
+import random
+from datetime import date
+from cprint import cprint
+import shutil
+from unipath import Path
+from jinja2 import Environment, FileSystemLoader
+
+PYP5_DIR = Path(__file__).parent
+TEMPLATES_DIR = PYP5_DIR.child('templates')
+TARGET_DIRNAME = "target"
+templates = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+
+
+
+def new_sketch(sketch_name, sketch_dir):
+    SKETCH_DIR = Path(sketch_dir or f'{sketch_name}')
+
+    if SKETCH_DIR.exists():
+        cprint.warn(f"Cannot configure a new sketch.")
+        cprint.err(f"The directory {SKETCH_DIR} already exists.", interrupt=True)
+
+    static_dir = SKETCH_DIR.child('static')
+    templates_files = [
+        (TEMPLATES_DIR.child('base_sketch.py'), SKETCH_DIR.child(f'{sketch_name}.py')),
+        (PYP5_DIR.child('static', 'p5.js'), static_dir.child('p5.js'))
+    ]
+
+    index_template = templates.get_template('index.html')
+    context = {
+        "p5_js_url": "static/p5.js",
+        "sketch_js_url": f"{TARGET_DIRNAME}/{sketch_name}.js",
+        "sketch_name": sketch_name,
+    }
+    index_contet = index_template.render(context)
+
+    os.mkdir(SKETCH_DIR)
+    os.mkdir(static_dir)
+    for src, dest in templates_files:
+        shutil.copyfile(src, dest)
+
+    with open(SKETCH_DIR.child("index.html"), "w") as fd:
+        fd.write(index_contet)
+
+    return templates_files[0][1]
+
+
+def _validate_sketch_paths(sketch_name=None, sketch_dir=None):
+    sketch_dir = Path(sketch_dir or f'{sketch_name}')
+
+    sketch = sketch_dir.child(f"{sketch_name}.py")
+    if not sketch.exists():
+        sketch_file = Path(os.getcwd()).child(f"{sketch_name}.py")
+        if not sketch_file.exists():
+            cprint.warn(f"Couldn't find the sketch.")
+            cprint.err(f"Neither the file {sketch} or {sketch_file} exist.", interrupt=True)
+
+        sketch = sketch_file
+        sketch_dir = sketch.parent
+
+    return sketch_dir, sketch
+
+
+def transcrypt_sketch(sketch_name, sketch_dir):
+    sketch_dir, sketch = _validate_sketch_paths(sketch_name, sketch_dir)
+
+    command = ' '.join([str(c) for c in [
+        'transcrypt', '-xp', PYP5_DIR, '-b', '-m', '-n', sketch
+    ]])
+    cprint.info(f"Converting Python to P5.js...\nRunning command:\n\t {command}")
+
+    proc = subprocess.Popen(shlex.split(command))
+    proc.wait()
+
+    __target = sketch_dir.child('__target__')
+    if not __target.exists():
+        cprint.err(f"Error with transcrypt: the {__target} directory wasn't created.", interrupt=True)
+
+    target_dir = sketch_dir.child(TARGET_DIRNAME)
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    shutil.move(__target, target_dir)
+
+    return sketch_dir.child("index.html")

--- a/pyp5js/compiler.py
+++ b/pyp5js/compiler.py
@@ -1,0 +1,30 @@
+import subprocess
+import shutil
+import shlex
+from cprint import cprint
+from unipath import Path
+
+
+PYP5_DIR = Path(__file__).parent
+
+
+def compile_sketch_js(sketch, target_name):
+    sketch_dir = sketch.parent
+
+    command = ' '.join([str(c) for c in [
+        'transcrypt', '-xp', PYP5_DIR, '-b', '-m', '-n', sketch
+    ]])
+
+    cprint.info(f"Converting Python to P5.js...\nRunning command:\n\t {command}")
+
+    proc = subprocess.Popen(shlex.split(command))
+    proc.wait()
+
+    __target = sketch_dir.child('__target__')
+    if not __target.exists():
+        cprint.err(f"Error with transcrypt: the {__target} directory wasn't created.", interrupt=True)
+
+    target_dir = sketch_dir.child(target_name)
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    shutil.move(__target, target_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Jinja2==2.10.1
 PyYAML==5.1
 Transcrypt==3.7.12
 Unipath==1.1
+watchdog==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 
+with open("requirements.txt") as fd:
+    requirements = [l.strip() for l in fd.readlines()]
+
 with open("README.md") as fd:
     long_description = fd.read()
 
@@ -26,12 +29,5 @@ setup(
         'console_scripts': ['pytop5js = pyp5js.cli:command_line_entrypoint']
     },
     python_requires='>=3.6',
-    install_requires=[
-        'Click==7.0',
-        'cprint==1.1',
-        'Jinja2==2.10.1',
-        'PyYAML==5.1',
-        'Transcrypt==3.7.12',
-        'Unipath==1.1',
-    ],
+    install_requires=requirements,
 )


### PR DESCRIPTION
Fixes #6 by introducing the CLI command:

```
$ py5top5js monitor test_sketch
Monitoring for changes in /home/bernardo/envs/pyp5js/test_sketch...
New change in test_sketch/test_sketch.py
Converting Python to P5.js...
Running command:
	 transcrypt -xp /home/bernardo/envs/pyp5js/pyp5js -b -m -n test_sketch/test_sketch.py

Transcrypt (TM) Python to JavaScript Small Sane Subset Transpiler Version 3.7.12
Copyright (C) Geatec Engineering. License: Apache 2.0


Saving target code in: /home/bernardo/envs/pyp5js/test_sketch/__target__/org.transcrypt.__runtime__.js
Saving target code in: /home/bernardo/envs/pyp5js/test_sketch/__target__/pyp5js.js
Saving target code in: /home/bernardo/envs/pyp5js/test_sketch/__target__/test_sketch.js

Ready

```