### PR TITLE
Fix pop instruction using __pragma__.

### DIFF
--- a/pyp5js/pytop5js.py
+++ b/pyp5js/pytop5js.py
@@ -233,7 +233,10 @@ def push(*args):
     return _P5_INSTANCE.push(*args)
 
 def pop(*args):
-    return _P5_INSTANCE.pop(*args)
+    __pragma__('noalias', 'pop')
+    p5_pop = _P5_INSTANCE.pop(*args)
+    __pragma__('alias', 'pop', 'py_pop')
+    return p5_pop
 
 def redraw(*args):
     return _P5_INSTANCE.redraw(*args)


### PR DESCRIPTION
Fix pop instruction using Transcrypt `__pragma__('alias')`.

I've tried to create a decorator for this function, but I was not able to call __pragma__ outside of pytop5js.py.

Fixes #3 

Screencast:

![pop_sketch](https://user-images.githubusercontent.com/418606/57250412-c308b100-701d-11e9-8618-0465b6046dbe.gif)
