### PR TITLE
Feature/http server

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,6 +1,10 @@
 Development
 -----------
 
+0.3.0 (in development)
+-----
+- Create `pyp5js serve` command (HTTP server, compiles sketches on the fly)
+
 0.2.0
 -----
 - Rename pyp5.js module from pytop5js to pyp5js

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 serve:
-		@python3 -m http.server
+		@pyp5js serve .
 
 compile:
 		@transcrypt -b -m -n sketch

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
 -r requirements.txt
+
+black==19.3b0
+ipython==7.8.0
 pytest==4.5.0
 tox==3.10.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,13 +22,17 @@ def draw():
     r = sin(frameCount / 60) * 50 + 50
     ellipse(100, 100, r, r)
 ```
+
 ## Examples
-[Click here](https://berinhard.github.io/pyp5js/examples/) to see a list of examples generated with `pyp5js`.
+
+[Click here](https://berinhard.github.io/pyp5js/examples/) to see a list of
+examples generated with `pyp5js`.
 
 
 ## Installation
 
-This project requires Python 3 and is now on PyPI, so you can install it with `pip` or `pip3`, depending on your environment:
+This project requires Python 3 and is now on PyPI, so you can install it with
+`pip` or `pip3`, depending on your environment:
 
 ```
 $ pip install pyp5js
@@ -37,7 +41,9 @@ $ pip install pyp5js
 
 ## Usage
 
-Since you'll be writting Python code and then generating the correspondent P5.js code from it, pyp5js provides a simple command line API to help you to generate the files.
+Since you'll be writting Python code and then generating the correspondent
+P5.js code from it, pyp5js provides a simple command line interface to help you
+to generate the files.
 
 So, to start a new sketch, you'll have to run:
 
@@ -55,15 +61,37 @@ This command will create a directory with the following code structure:
   - my_sketch.py
 ```
 
-The `index.html` is prepared to display your sketch, so you'll have to keep it open in your browser (I really advise you to use [Firefox](https://www.mozilla.org/en-US/firefox/new/)) to see results from the code you'll add to `my_sketch.py`.
+The `index.html` is prepared to display your sketch, so you'll have to keep it
+open in your browser (I really advise you to use
+[Firefox](https://www.mozilla.org/en-US/firefox/new/)) to see results from the
+code you'll add to `my_sketch.py`.
 
-After updating your code, you'll have to run the `transcrypt` command to update the files. Run it as:
+To see your app on your browser you'll need to run a Web server (opening the
+"index.html" file directly won't work since [it is disabled by
+default](https://github.com/berinhard/pyp5js/issues/72)) - we packaged it
+already for you, just run:
+
+```bash
+$ pyp5js serve .
+# You may replace "." with any other path containing sketches.
+```
+
+Then point your browser to [http://localhost:8765/](http://localhost:8765/) and
+click on the sketches available. This command will compile the sketches on the
+fly, so after changing/saving the sketch file you just need to reload the page
+on your browser.
+
+If you just want to compile your code (without running the Web server) there's
+the `transcrypt` command:
 
 ```
 $ pyp5js transcrypt my_sketch
 ```
 
-If you're lazy as me, you can use the `monitor` command instead of the previous one. The command will monitor your sketch directory and keep track of any changes on any `.py` files. When it notices a new change, it automatically runs the transcrypt process for you. So, now you'll just have to refresh your `index.html` file in your browser to see the results.
+If you're lazy as me, you can use the `monitor` command instead of the previous
+one. The command will monitor your sketch directory and keep track of any
+changes on any `.py` files. When it notices a new change, it automatically runs
+the transcrypt process for you:
 
 ```
 $ pyp5js monitor my_sketch
@@ -75,7 +103,8 @@ You can also use the `monitor` command within the `new` by running:
 $ pyp5js new my_sketch --monitor
 ```
 
-All of the command-line interface methods have a few optional arguments, such as specifying the sketch directory. You can check them by running:
+All of the command-line interface methods have a few optional arguments, such
+as specifying the sketch directory. You can check them by running:
 
 ```
 $ pyp5js --help

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from pathlib import Path
+
 from cprint import cprint
 import click
 
@@ -85,6 +87,23 @@ def monitor_sketch(sketch_name, sketch_dir):
     $ pyp5js monitor my_sketch
     """
     commands.monitor_sketch(sketch_name, sketch_dir)
+
+
+@command_line_entrypoint.command("serve")
+@click.argument("sketches_path")
+@click.option("--host", default="127.0.0.1")
+@click.option("--port", default=8765)
+@click.option("--workers", default=4)
+def serve_sketches(sketches_path, host, port, workers):
+    """Run HTTP server to compile and serve sketches"""
+
+    sketches_path = Path(sketches_path)
+    if not sketches_path.exists():
+        cprint.err(f"ERROR: path <{sketches_path}> does not exist.")
+        exit(1)
+
+    commands.serve_http(sketches_path, host, port, workers)
+
 
 if __name__ == "__main__":
     command_line_entrypoint()

--- a/pyp5js/commands.py
+++ b/pyp5js/commands.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+
 from cprint import cprint
 from jinja2 import Environment, FileSystemLoader
 
@@ -7,6 +8,7 @@ from pyp5js.compiler import compile_sketch_js
 from pyp5js.fs import Pyp5jsSketchFiles, Pyp5jsLibFiles
 from pyp5js.monitor import monitor_sketch as monitor_sketch_service
 from pyp5js.templates_renderer import get_index_content
+from pyp5js.http import StandaloneApplication, sketch_files_app
 
 
 def new_sketch(sketch_name, sketch_dir):
@@ -91,3 +93,10 @@ def monitor_sketch(sketch_name, sketch_dir):
         monitor_sketch_service(sketch_files)
     except KeyboardInterrupt:
         cprint.info("Exiting monitor...")
+
+
+def serve_http(sketches_path, host, port, workers):
+    """Run a HTTP server which compiles sketches on the fly and serves static files"""
+
+    options = {"bind": f"{host}:{port}", "workers": workers}
+    StandaloneApplication(sketch_files_app(sketches_path), options).run()

--- a/pyp5js/http.py
+++ b/pyp5js/http.py
@@ -1,0 +1,145 @@
+import glob
+import mimetypes
+import os
+from pathlib import Path
+from textwrap import dedent
+
+import gunicorn.app.base
+
+from pyp5js.compiler import compile_sketch_js
+from pyp5js.fs import Pyp5jsSketchFiles
+
+
+def make_sketches_list(path):
+    """Retrieve all sketches from a path an return a HTML page with links"""
+
+    template = dedent(
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>pyp5js server</title>
+        </head>
+        <body>
+          Available sketches:
+          <ul>
+        {{PLACEHOLDER}}
+          </ul>
+        </body>
+        </html>
+    """
+    ).strip()
+
+    # Get all sub-directories which has a Python file inside, except "pyp5js"
+    sketches = set(
+        str(Path(os.path.dirname(filepath)).relative_to(path))
+        for filepath in glob.glob(str(path / "*/*.py"))
+    )
+    if "pyp5js" in sketches:
+        sketches.remove("pyp5js")
+
+    return template.replace(
+        "{{PLACEHOLDER}}",
+        "\n".join(
+            f'    <li> <a href="{sketch}">{sketch}</a> </li>' for sketch in sorted(sketches)
+        ),
+    )
+
+
+def get_response_data(fobj):
+    """Prepare HTTP response headers and body based on a fobj
+
+    Note: not safe for large files (all the contents will be loaded in memory)
+    """
+
+    response_body = fobj.read()
+    response_headers = [
+        ("Content-Type", mimetypes.guess_type(fobj.name)[0]),
+        ("Content-Length", str(len(response_body))),
+    ]
+    return response_headers, response_body
+
+
+def sketch_files_app(base_path):
+    """Handle WSGI requests to serve sketches (compiles + serve static files)"""
+
+    base_path = base_path.resolve()  # must be a pathlib.Path instance
+    base_path_str = str(base_path)
+
+    def handler_app(environ, start_response):
+        request_path = environ["PATH_INFO"]
+
+        if request_path[0] == "/":
+            # Remove slash from the beginning of the string so we can easily
+            # operate this string as a sub-path from our base path
+            # (`base_path / request_path` will work without overwritting
+            # `base_path`).
+            request_path = request_path[1:]
+
+        if request_path == "":
+            # Home page - list all available sketches on `base_path`.
+            start_response("200 OK", [("Content-Type", "text/html")])
+            return [make_sketches_list(base_path).encode("utf-8")]
+
+        full_path = (base_path / request_path).resolve()
+        if not str(full_path).startswith(base_path_str):
+            # User tried something not allowed (as "/root/something" or "../xxx")
+            start_response("403 FORBIDDEN", [("Content-Type", "text/plain")])
+            return [b"Get out"]
+
+        elif not full_path.exists():
+            # Ouch, file/path not found (the endpoint for favicons, usually)
+            start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
+            return [b"File not found =/"]
+
+        else:
+            # Found an existing path (sketch) or a file
+
+            if full_path.is_dir():
+                # Probably inside a sketch directory, let's compile it
+                # XXX: the sketch Python file should be the same as it's parent
+                # directory name. Example: /home/user/mysketches/s1/s1.py
+                sketch_files = Pyp5jsSketchFiles(
+                    str(full_path.absolute()),
+                    str(full_path.name)
+                )
+                if not sketch_files.check_sketch_exists():
+                    start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
+                    return [b"Sketch not found =/"]
+                compile_sketch_js(sketch_files)
+
+                # TODO: should not compile sketch if file is not changed
+                full_path = full_path / "index.html"
+
+            with open(full_path, mode="rb") as fobj:
+                response_headers, response_body = get_response_data(fobj)
+                start_response("200 OK", response_headers)
+                return [response_body]
+
+    return handler_app
+
+
+class StandaloneApplication(gunicorn.app.base.BaseApplication):
+    """Standalone gunicorn application
+
+    Got from: <https://github.com/benoitc/gunicorn/blob/master/examples/standalone_app.py>
+    """
+
+    def __init__(self, app, options=None):
+        self.options = options or {}
+        self.application = app
+        super().__init__()
+
+    def load_config(self):
+        config = {
+            key: value
+            for key, value in self.options.items()
+            if key in self.cfg.settings and value is not None
+        }
+        for key, value in config.items():
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Click==7.0
-cprint==1.1
 Jinja2==2.10.1
 PyYAML==5.1
 Transcrypt==3.7.12
 Unipath==1.1
+cprint==1.1
+gunicorn==19.9.0
 watchdog==0.9.0


### PR DESCRIPTION
This PR implements `pyp5js serve` command, which runs a HTTP server based on gunicorn. Fixes #72.

Highlights:
- `serve` expects a "base path" (like `pyp5js serve .`) which contains sketches inside (each sketch having its own directory);
- Server will be available at http://localhost:8765/
- Home page will show the list of available sketches with links (still needs interface improvements)
- All sketches are compiled on the fly (as the request to http://localhost:8765/sketch-name happen)
- No files outside "base path" are served and all files which are not sketches are served as static files