### PR TITLE
Add unit tests to Web App

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,5 @@ ipython==7.8.0
 pytest==4.5.0
 tox==3.10.0
 pytest-env==0.6.2
+Flask-Testing==0.7.1
+blinker==1.4

--- a/pyp5js/http/web_app.py
+++ b/pyp5js/http/web_app.py
@@ -14,8 +14,6 @@ app = Flask(__name__)
 @app.route("/")
 def sketches_list_view():
     sketches = []
-    if not SKETCHBOOK_DIR.exists():
-        SKETCHBOOK_DIR.mkdir()
     for sketch_dir in (p for p in SKETCHBOOK_DIR.iterdir() if p.is_dir()):
         name = sketch_dir.name
         sketch_files = SketchFiles(name)
@@ -37,16 +35,17 @@ def add_new_sketch_view():
         sketch_name = slugify(request.form.get('sketch_name', '').strip(), separator='_')
         if not sketch_name:
             context['error'] = "You have to input a sketch name to proceed."
-        try:
-            files = commands.new_sketch(sketch_name)
-            template = 'new_sketch_success.html'
-            context.update({
-                'files': files,
-                'sketch_url': f'/sketch/{sketch_name}/',
-            })
-        except SketchDirAlreadyExistException:
-            path = SKETCHBOOK_DIR.joinpath(sketch_name)
-            context['error'] = f"The sketch {path} already exists."
+        else:
+            try:
+                files = commands.new_sketch(sketch_name)
+                template = 'new_sketch_success.html'
+                context.update({
+                    'files': files,
+                    'sketch_url': f'/sketch/{sketch_name}/',
+                })
+            except SketchDirAlreadyExistException:
+                path = SKETCHBOOK_DIR.joinpath(sketch_name)
+                context['error'] = f"The sketch {path} already exists."
 
     return render_template(template, **context)
 

--- a/pyp5js/http/web_app.py
+++ b/pyp5js/http/web_app.py
@@ -14,6 +14,8 @@ app = Flask(__name__)
 @app.route("/")
 def sketches_list_view():
     sketches = []
+    if not SKETCHBOOK_DIR.exists():
+        SKETCHBOOK_DIR.mkdir()
     for sketch_dir in (p for p in SKETCHBOOK_DIR.iterdir() if p.is_dir()):
         name = sketch_dir.name
         sketch_files = SketchFiles(name)

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -1,0 +1,15 @@
+from pyp5js.http.web_app import app
+from unittest import TestCase
+
+class WebAppTests(TestCase):
+
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True 
+
+    def tearDown(self):
+        pass
+
+    def test_home_status_code(self):
+        result = self.app.get('/') 
+        assert result.status_code == 200

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -1,8 +1,10 @@
+import os
+import shutil
+from pyp5js.config import SKETCHBOOK_DIR
 from pyp5js.http.web_app import app as web_app
 from flask_testing import TestCase
 
-class WebAppTests(TestCase):
-
+class Pyp5jsWebTestCase(TestCase):
     render_templates = False
 
     def create_app(self):
@@ -10,10 +12,45 @@ class WebAppTests(TestCase):
         app.config['TESTING'] = True
         return app
 
+    def setUp(self):
+        if not SKETCHBOOK_DIR.exists():
+            SKETCHBOOK_DIR.mkdir()
+
+    def tearDown(self):
+        if SKETCHBOOK_DIR.exists():
+            shutil.rmtree(SKETCHBOOK_DIR)
+
+    def create_sketch(self, name):
+        return os.makedirs(SKETCHBOOK_DIR.joinpath(name))
+
+
+class IndexViewTests(Pyp5jsWebTestCase):
+    route = '/'
+
     def test_get_home_renders_index_template(self):
-        self.client.get('/')
+        self.client.get(self.route)
         self.assert_template_used('index.html')
 
+
+class NewSketchViewTests(Pyp5jsWebTestCase):
+    route = '/new-sketch/'
+
     def test_get_new_sketch_renders_new_sketch_form_template(self):
-        self.client.get('/new-sketch/')
+        self.client.get(self.route)
         self.assert_template_used('new_sketch_form.html')
+
+    def test_post_without_sketch_name_should_render_form_with_error(self):
+        self.client.post(self.route, data=dict(sketch_name=''))
+        self.assert_template_used('new_sketch_form.html')
+        self.assert_context('error', 'You have to input a sketch name to proceed.')
+
+    def test_post_with_existing_sketch_name_should_render_form_with_error(self):
+        self.create_sketch('my_existing_sketch')
+        self.client.post(self.route, data=dict(sketch_name='my_existing_sketch'))
+        self.assert_template_used('new_sketch_form.html')
+        self.assert_context('error', 'The sketch tests-sketchbook/my_existing_sketch already exists.')
+
+    def test_post_with_sketch_name_should_render_success_form(self):
+        self.client.post(self.route, data=dict(sketch_name='a_name'))
+        self.assert_template_used('new_sketch_success.html')
+

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -50,7 +50,7 @@ class IndexViewTests(Pyp5jsWebTestCase):
         self.assert_template_used('index.html')
         self.assert_context('sketches', [
             dict(name='first_sketch', url='/sketch/first_sketch'),
-            dict(name='second_sketch', url='/sketch/second_sketch')
+            dict(name='second_sketch', url='/sketch/second_sketch'),
         ])
 
 

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -38,9 +38,20 @@ class Pyp5jsWebTestCase(TestCase):
 class IndexViewTests(Pyp5jsWebTestCase):
     route = '/'
 
-    def test_get_home_renders_index_template(self):
+    def test_get_home_renders_index_template_and_context_with_empty(self):
         self.client.get(self.route)
         self.assert_template_used('index.html')
+        self.assert_context('sketches', [])
+
+    def test_get_home_renders_index_template_and_context_all_files(self):
+        self.create_sketch('first_sketch')
+        self.create_sketch('second_sketch')
+        self.client.get(self.route)
+        self.assert_template_used('index.html')
+        self.assert_context('sketches', [
+            dict(name='first_sketch', url='/sketch/first_sketch'),
+            dict(name='second_sketch', url='/sketch/second_sketch')
+        ])
 
 
 class NewSketchViewTests(Pyp5jsWebTestCase):

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -48,10 +48,9 @@ class IndexViewTests(Pyp5jsWebTestCase):
         self.create_sketch('second_sketch')
         self.client.get(self.route)
         self.assert_template_used('index.html')
-        self.assert_context('sketches', [
-            dict(name='first_sketch', url='/sketch/first_sketch'),
-            dict(name='second_sketch', url='/sketch/second_sketch'),
-        ])
+        assert len(self.get_context_variable('sketches')) == 2
+        assert dict(name='first_sketch', url='/sketch/first_sketch') in self.get_context_variable('sketches')
+        assert dict(name='second_sketch', url='/sketch/second_sketch') in self.get_context_variable('sketches')
 
 
 class NewSketchViewTests(Pyp5jsWebTestCase):

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -26,7 +26,7 @@ class Pyp5jsWebTestCase(TestCase):
         target_file = sketch_dir.joinpath(f'{name}.py')
         index_file = sketch_dir.joinpath('index.html')
         self.create_file(target_file)
-        self.create_file(index_file)
+        self.create_file(index_file, 'index file content')
         return sketch_dir
 
     def create_sketch_with_static_files(self, name, static_path):
@@ -38,16 +38,13 @@ class Pyp5jsWebTestCase(TestCase):
         static_file = static_dir.joinpath(static_path.split('/')[1])
         self.create_file(target_file)
         self.create_file(index_file)
-        self.create_static_file(static_file)
+        self.create_file(static_file, 'static file content')
         return sketch_dir
 
-    def create_file(self, file_name):
+    def create_file(self, file_name, content=''):
         with file_name.open('w') as fd:
-            fd.write('')
+            fd.write(content)
 
-    def create_static_file(self, file_name):
-        with file_name.open('w') as fd:
-            fd.write('static file content')
 
 class IndexViewTests(Pyp5jsWebTestCase):
     route = '/'
@@ -91,6 +88,7 @@ class SketchViewTests(Pyp5jsWebTestCase):
         self.create_sketch('sketch_exists')
         response = self.client.get(self.route + 'sketch_exists/')
         self.assert_200(response)
+        self.assertEqual(response.data, b"index file content")
 
     def test_get_static_file_does_not_exist(self):
         response = self.client.get(self.route + 'foo/static/file.js')
@@ -101,6 +99,7 @@ class SketchViewTests(Pyp5jsWebTestCase):
         response = self.client.get(self.route + 'foo/static/file.js')
         self.assert_200(response)
         self.assertEqual(response.headers['Content-Type'], 'application/javascript')
+        self.assertEqual(response.data, b"static file content")
 
     def test_get_static_file(self):
         self.create_sketch_with_static_files('foo', 'static/style.css')

--- a/pyp5js/tests/http/test_web_app.py
+++ b/pyp5js/tests/http/test_web_app.py
@@ -1,15 +1,19 @@
-from pyp5js.http.web_app import app
-from unittest import TestCase
+from pyp5js.http.web_app import app as web_app
+from flask_testing import TestCase
 
 class WebAppTests(TestCase):
 
-    def setUp(self):
-        self.app = app.test_client()
-        self.app.testing = True 
+    render_templates = False
 
-    def tearDown(self):
-        pass
+    def create_app(self):
+        app = web_app
+        app.config['TESTING'] = True
+        return app
 
-    def test_home_status_code(self):
-        result = self.app.get('/') 
-        assert result.status_code == 200
+    def test_get_home_renders_index_template(self):
+        self.client.get('/')
+        self.assert_template_used('index.html')
+
+    def test_get_new_sketch_renders_new_sketch_form_template(self):
+        self.client.get('/new-sketch/')
+        self.assert_template_used('new_sketch_form.html')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 env =
-    SKETCHBOOK_DIR=tests-skecthbook
+    SKETCHBOOK_DIR=tests-sketchbook


### PR DESCRIPTION
[WIP]
I've created the PR already just to register some findings and to discuss the implementation. Please check the comments.
Here is the checklist with the tests needed from the issue https://github.com/berinhard/pyp5js/issues/81:

**Route /**

- [x] Ensure the sketches are being listed with valid links
- [x] On GET should render index.html form (suggestion)

**Route /new-sketch/**

- [x] On GET should render the new sketch form
- [x] POST without sketch_name should render the form again with an error message
- [x] POST with an existing sketch_name should render the form again with an error message
- [x] POST with a valid sketch_name should create the new sketch directory and files and render success page

**Route /sketch/<sketch_name>**

- [x] 404 if sketch does not exist
- [x] Should return the sketch's index.html if it exists
- [x] Should add the sketch's static files when the route has an additional path, such as /sketch/foo/static/style.css
- [x] Set Content-Type=application/javascript header for the javascript files;
- [x] 404 if the static file does not exist