### PR TITLE
Added detection for directory traversal attack edge case

### DIFF
--- a/pyp5js/http/web_app.py
+++ b/pyp5js/http/web_app.py
@@ -56,8 +56,11 @@ def render_sketch_view(sketch_name, static_path):
 
     content_file = sketch_files.index_html
     if static_path:
-        content_file = sketch_files.sketch_dir.joinpath(static_path)
-        if not content_file.exists():
+        content_file = sketch_files.sketch_dir.joinpath(static_path).resolve()
+        if not str(content_file).startswith(str(sketch_files.sketch_dir)):
+            # User tried something not allowed (as "/root/something" or "../xxx")
+            return '', 403
+        elif not content_file.exists():
             return '', 404
     else:
         try:


### PR DESCRIPTION
Most web server software as well as modern web browsers will automatically detect potential directory traversal attacks by resolving the URL before processing it, including the Flask built-in development server, but there might be some edge case configuration that would allow one to slip through. This check prevents such an scenario. I kept the comment from the original pre-refactor code.