### PR TITLE
Keep Python functions with name conflict with p5.js working as expected

### DIFF
--- a/pyp5js/pyp5js.py
+++ b/pyp5js/pyp5js.py
@@ -1,3 +1,6 @@
+from pyp5js.python_functions import PythonFunctions
+
+_PYTHON_INSTANCE = PythonFunctions()
 _P5_INSTANCE = None
 _CTX_MIDDLE = None
 _DEFAULT_FILL = None
@@ -557,7 +560,10 @@ def copy(*args):
     return _P5_INSTANCE.copy(*args)
 
 def filter(*args):
-    return _P5_INSTANCE.filter(*args)
+    if (len(args) > 1) and (type(args[1]) == type([])):
+        return _PYTHON_INSTANCE.python_filter(*args)
+    else:
+        return _P5_INSTANCE.filter(*args)
 
 def get(*args):
     return _P5_INSTANCE.get(*args)
@@ -566,7 +572,10 @@ def loadPixels(*args):
     return _P5_INSTANCE.loadPixels(*args)
 
 def set(*args):
-    return _P5_INSTANCE.set(*args)
+    if len(args) == 1:
+        return _PYTHON_INSTANCE.python_set(*args)
+    else:
+        return _P5_INSTANCE.set(*args)
 
 def updatePixels(*args):
     return _P5_INSTANCE.updatePixels(*args)
@@ -662,7 +671,10 @@ def mag(*args):
     return _P5_INSTANCE.mag(*args)
 
 def map(*args):
-    return _P5_INSTANCE.map(*args)
+    if (len(args) > 1) and (type(args[1]) == type([])):
+        return _PYTHON_INSTANCE.python_map(*args)
+    else:
+        return _P5_INSTANCE.map(*args)
 
 def max(*args):
     return _P5_INSTANCE.max(*args)

--- a/pyp5js/pyp5js.py
+++ b/pyp5js/pyp5js.py
@@ -572,7 +572,7 @@ def loadPixels(*args):
     return _P5_INSTANCE.loadPixels(*args)
 
 def set(*args):
-    if len(args) == 1:
+    if len(args) <= 1:
         return _PYTHON_INSTANCE.python_set(*args)
     else:
         return _P5_INSTANCE.set(*args)

--- a/pyp5js/pyp5js.py
+++ b/pyp5js/pyp5js.py
@@ -560,7 +560,7 @@ def copy(*args):
     return _P5_INSTANCE.copy(*args)
 
 def filter(*args):
-    if (len(args) > 1) and (type(args[1]) == type([])):
+    if (len(args) > 1) and callable(args[0]):
         return _PYTHON_INSTANCE.filter(*args)
     else:
         return _P5_INSTANCE.filter(*args)
@@ -671,7 +671,7 @@ def mag(*args):
     return _P5_INSTANCE.mag(*args)
 
 def map(*args):
-    if (len(args) > 1) and (type(args[1]) == type([])):
+    if (len(args) > 1) and callable(args[0]):
         return _PYTHON_INSTANCE.map(*args)
     else:
         return _P5_INSTANCE.map(*args)

--- a/pyp5js/pyp5js.py
+++ b/pyp5js/pyp5js.py
@@ -561,7 +561,7 @@ def copy(*args):
 
 def filter(*args):
     if (len(args) > 1) and (type(args[1]) == type([])):
-        return _PYTHON_INSTANCE.python_filter(*args)
+        return _PYTHON_INSTANCE.filter(*args)
     else:
         return _P5_INSTANCE.filter(*args)
 
@@ -573,7 +573,7 @@ def loadPixels(*args):
 
 def set(*args):
     if len(args) <= 1:
-        return _PYTHON_INSTANCE.python_set(*args)
+        return _PYTHON_INSTANCE.set(*args)
     else:
         return _P5_INSTANCE.set(*args)
 
@@ -672,7 +672,7 @@ def mag(*args):
 
 def map(*args):
     if (len(args) > 1) and (type(args[1]) == type([])):
-        return _PYTHON_INSTANCE.python_map(*args)
+        return _PYTHON_INSTANCE.map(*args)
     else:
         return _P5_INSTANCE.map(*args)
 

--- a/pyp5js/python_functions.py
+++ b/pyp5js/python_functions.py
@@ -1,0 +1,9 @@
+class PythonFunctions:
+    def python_map(self, *args):
+        return map(*args)
+
+    def python_filter(self, *args):
+        return filter(*args)
+
+    def python_set(self, *args):
+        return set(*args)

--- a/pyp5js/python_functions.py
+++ b/pyp5js/python_functions.py
@@ -1,9 +1,5 @@
-class PythonFunctions:
-    def python_map(self, *args):
-        return map(*args)
+class PythonFunctions: pass
 
-    def python_filter(self, *args):
-        return filter(*args)
-
-    def python_set(self, *args):
-        return set(*args)
+setattr(PythonFunctions, 'map', map)
+setattr(PythonFunctions, 'filter', filter)
+setattr(PythonFunctions, 'set', set)


### PR DESCRIPTION
Solve issue https://github.com/berinhard/pyp5js/issues/90

- Add a wrapper class to python functions called `PythonFunctions` because I am not able to call the python methods from `pyp5js.py` since they conflict with the defined methods from this file
- For `map` and `filter` functions I check if there are more than two arguments passed, if so, then if the second one is a list then the python method should be called
- For `set` function I check if only one argument is passed then the python method should be called
- One thing that I struggled with was creating unit tests for this scenarios, since it is difficult to mock the `_P5_INSTANCE`, so I tested everything manually which is not ideal. Do you have any suggestions @berinhard ?