### PR TITLE
Removing the PVector warning for now

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -143,8 +143,6 @@ $ pyp5js --help
 
 - There are no Py.Processing `with` context facilities for `push/pop` or `beginShape/endShape`.
 
-- There are no `PVector` objects, with their nice syntatic operator overloaded sugar - use `p5.Vector` with `createVector()` and P5.js conventions ... for now...
-
 - For the `mouseWheel()` event funtion, use `def mouseWheel()` with NO parameters, then, inside the function, the magic `event.delta` will have a value equivalent to the one returned by Java&Python Mode's `event.getCount()`.
 
 - At this point, it is a known limitation that you have to "declare" global variables before `setup()` and `draw()`, maybe using `name = None`, as they can't be created inside methods.


### PR DESCRIPTION
According to suggestion by @felipesanches https://github.com/berinhard/pyp5js/pull/137#issuecomment-821820876