### PR TITLE
Introduce new flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Development
 - Pyodide examples in the docs
 - Upgrade Transcrypt to 3.9.0
 - Upgrade Pyodide to v0.17.0
+- Enable to use custom templates files to generate and compile index.html
 
 0.5.2
 -----

--- a/docs/examples/transcrypt/index.html.template
+++ b/docs/examples/transcrypt/index.html.template
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+
+<!-- pyp5js index.html boilerplate -->
+<html lang="">
+  <head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ sketch_name }} - pyp5js</title>
+    <style> body, html, canvas {padding: 0; margin: 0; overflow: hidden;} </style>
+
+    <script src="{{ p5_js_url }}"></script>
+    <script src="{{ sketch_js_url }}"  type="module"></script>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/default.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
+
+    <style>
+        html {
+          overflow-y: scroll;
+          overflow-x: scroll;
+        }
+
+        .demoContainer {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        pre {
+            padding-left: 2em;
+        }
+    </style>
+  </head>
+
+  <body>
+    <p style="background-color: #f6f8fa">
+      Python code <a href="https://github.com/berinhard/pyp5js/blob/develop/docs/examples/transcrypt/{{ sketch_name }}" target="_blank">here</a>.
+    </p>
+
+    <div class="demoContainer">
+        <div id="sketch-holder" style="">
+              <!-- You sketch will go here! -->
+        </div>
+
+        <div style="">
+          <pre>
+             <code>
+{{ sketch_content }}
+              </code>
+          </pre>
+        </div>
+
+    </div>
+  </body>
+</html>

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -27,8 +27,6 @@ def configure_new_sketch(sketch_name, monitor, interpreter, template):
     Create dir and configure boilerplate - Example:\n
     $ pyp5js new my_sketch -i pyodide
     """
-    if template:
-        template = Path(template)
     files = commands.new_sketch(sketch_name, interpreter, template_file=template)
 
     cprint.ok(f"Your sketch was created!")

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -46,13 +46,8 @@ def configure_new_sketch(sketch_name, monitor, interpreter, template):
 @click.argument("sketch_name")
 def transcrypt_sketch(sketch_name):
     """
-    Command to generate the P5.js code for a python sketch
-
-    Params:
-
-    - sketch_name: name of the sketch
-
-    Example:
+    [DEPRECATED] Command to generate the P5.js code for a python sketch
+    \nExample:
     $ pyp5js transcrypt my_sketch
     """
     msg = f"transcript command is deprecated. Instead, please run: \n\n\tpyp5js compile {sketch_name}\n"
@@ -63,6 +58,11 @@ def transcrypt_sketch(sketch_name):
 @click.argument("sketch_name")
 @click.option('--refresh', is_flag=True, help="Update the skech index.html before it ends.")
 def compile_sketch(sketch_name, refresh):
+    """
+    Command to update your sketch files (index, js codes etc)
+    \nExample:
+    $ pyp5js compile my_sketch
+    """
     files = commands.compile_sketch(sketch_name, refresh)
     cprint.ok(f"Your sketch is ready and available at file://{files.index_html.absolute()}")
 
@@ -73,29 +73,21 @@ def monitor_sketch(sketch_name):
     """
     Command to generate keep watching a sketch's dir and, after any change,
     it'll automatically generate the JS files as in pyp5js transcrypt command
-
-    Params:
-
-    - sketch_name: name of the sketch
-
-    Example:
-
-    $ pyp5js monitor my_sketch
     """
     commands.monitor_sketch(sketch_name)
 
 
 @command_line_entrypoint.command("serve")
-@click.option("--host", default="127.0.0.1")
-@click.option("--port", default=5000)
-@click.option('--debug', is_flag=True)
+@click.option("--host", default="127.0.0.1", help="HTTP server host (defaults to 127.0.0.1)")
+@click.option("--port", default=5000, help="Listened by the server (defaults to 5000)")
+@click.option('--debug', is_flag=True, help="Debug mode: re-run server after any file update")
 def serve_sketches(host, port, debug):
     """
     Run HTTP server to compile and serve sketches
 
     Opitionals:
-    - host: http server host (defaults to 127.0.0.1)
-    - port: listened by the server (defaults to 5000)
+    - host:
+    - port:
 
     Example:
     $ pyp5js serve

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -61,8 +61,9 @@ def transcrypt_sketch(sketch_name):
 
 @command_line_entrypoint.command("compile")
 @click.argument("sketch_name")
-def compile_sketch(sketch_name):
-    files = commands.compile_sketch(sketch_name)
+@click.option('--refresh', is_flag=True, help="Update the skech index.html before it ends.")
+def compile_sketch(sketch_name, refresh):
+    files = commands.compile_sketch(sketch_name, refresh)
     cprint.ok(f"Your sketch is ready and available at file://{files.index_html.absolute()}")
 
 

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -21,12 +21,15 @@ def command_line_entrypoint():
 @click.argument('sketch_name')
 @click.option('--monitor', '-m', is_flag=True, help='Starts the monitor command too')
 @click.option('--interpreter', '-i', type=click.Choice(AVAILABLE_INTERPRETERS), default=PYODIDE_INTERPRETER, help='Which python tool to use to run the sketch. (defaults to pyodide)')
-def configure_new_sketch(sketch_name, monitor, interpreter):
+@click.option('--template', '-t', type=click.Path(exists=True), help='Specify a custom index.html template to use.')
+def configure_new_sketch(sketch_name, monitor, interpreter, template):
     """
     Create dir and configure boilerplate - Example:\n
     $ pyp5js new my_sketch -i pyodide
     """
-    files = commands.new_sketch(sketch_name, interpreter)
+    if template:
+        template = Path(template)
+    files = commands.new_sketch(sketch_name, interpreter, template_file=template)
 
     cprint.ok(f"Your sketch was created!")
 

--- a/pyp5js/commands.py
+++ b/pyp5js/commands.py
@@ -14,12 +14,13 @@ from pyp5js.templates_renderers import get_sketch_index_content
 from pyp5js.config import PYODIDE_INTERPRETER
 
 
-def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER):
+def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=None):
     """
     Creates a new sketch with the required assets and a index.html file, based on pyp5js's templates
 
     :param sketch_name: name for new sketch
     :param interpreter: interpreter to use (transcrypt or pyodide)
+    :param template_file: use a custom template for index.html instead of default one
     :type sketch_name: string
     :return: file names
     :rtype: list of strings
@@ -34,7 +35,7 @@ def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER):
     for src, dest in templates_files:
         shutil.copyfile(src, dest)
 
-    index_contet = get_sketch_index_content(sketch)
+    index_contet = get_sketch_index_content(sketch, template_file=template_file)
     with open(sketch.index_html, "w") as fd:
         fd.write(index_contet)
 

--- a/pyp5js/commands.py
+++ b/pyp5js/commands.py
@@ -42,11 +42,12 @@ def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=""):
     return sketch
 
 
-def compile_sketch(sketch_name):
+def compile_sketch(sketch_name, generate_index=False):
     """
     Transcrypt the sketch python code to javascript.
 
     :param sketch_name: name for new sketch
+    :param generate_index: boolean to flag if the index.html file should be updated
     :type sketch_name: string
     :return: file names
     :rtype: list of strings
@@ -59,6 +60,12 @@ def compile_sketch(sketch_name):
         raise PythonSketchDoesNotExist(sketch)
 
     compile_sketch_js(sketch)
+    if generate_index:
+        index_contet = get_sketch_index_content(sketch)
+        with open(sketch.index_html, "w") as fd:
+            fd.write(index_contet)
+        cprint.info(f"{sketch.index_html.resolve()} updated")
+
     return sketch
 
 

--- a/pyp5js/commands.py
+++ b/pyp5js/commands.py
@@ -14,7 +14,7 @@ from pyp5js.templates_renderers import get_sketch_index_content
 from pyp5js.config import PYODIDE_INTERPRETER
 
 
-def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=None):
+def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=""):
     """
     Creates a new sketch with the required assets and a index.html file, based on pyp5js's templates
 
@@ -25,7 +25,7 @@ def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=None)
     :return: file names
     :rtype: list of strings
     """
-    sketch = Sketch(sketch_name, interpreter=interpreter)
+    sketch = Sketch(sketch_name, interpreter=interpreter, index_template=template_file)
     sketch.create_sketch_dir()
 
     templates_files = [
@@ -35,7 +35,7 @@ def new_sketch(sketch_name, interpreter=PYODIDE_INTERPRETER, template_file=None)
     for src, dest in templates_files:
         shutil.copyfile(src, dest)
 
-    index_contet = get_sketch_index_content(sketch, template_file=template_file)
+    index_contet = get_sketch_index_content(sketch)
     with open(sketch.index_html, "w") as fd:
         fd.write(index_contet)
 

--- a/pyp5js/config/sketch.py
+++ b/pyp5js/config/sketch.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from pyp5js.config.fs import PYP5JS_FILES
 
@@ -13,12 +14,20 @@ class SketchConfig:
             config_data = json.load(fd)
             return cls(**config_data)
 
-    def __init__(self, interpreter):
+    def __init__(self, interpreter, index_template=""):
         self.interpreter = interpreter
+        self.index_template = index_template # must be a string
+
+    @property
+    def index_template_path(self):
+        return Path(self.index_template).absolute()
 
     def write(self, fname):
         with open(fname, "w") as fd:
-            data = {"interpreter": self.interpreter}
+            data = {
+                "interpreter": self.interpreter,
+                "index_template": str(Path(self.index_template_path).resolve())
+            }
             json.dump(data, fd)
 
     @property
@@ -30,6 +39,8 @@ class SketchConfig:
         return self.interpreter == PYODIDE_INTERPRETER
 
     def get_index_template(self):
+        if self.index_template and self.index_template_path.exists():
+            return self.index_template_path
         index_map = {
             TRANSCRYPT_INTERPRETER: PYP5JS_FILES.transcrypt_index_html,
             PYODIDE_INTERPRETER: PYP5JS_FILES.pyodide_index_html,

--- a/pyp5js/config/sketch.py
+++ b/pyp5js/config/sketch.py
@@ -23,10 +23,13 @@ class SketchConfig:
         return Path(self.index_template).absolute()
 
     def write(self, fname):
+        index_template = ""
+        if self.index_template and self.index_template_path.exists():
+            index_template = str(self.index_template_path.resolve())
         with open(fname, "w") as fd:
             data = {
                 "interpreter": self.interpreter,
-                "index_template": str(Path(self.index_template_path).resolve())
+                "index_template": index_template
             }
             json.dump(data, fd)
 

--- a/pyp5js/sketch.py
+++ b/pyp5js/sketch.py
@@ -49,6 +49,8 @@ class Sketch:
 
     @property
     def sketch_content(self):
+        if not self.sketch_py.exists():
+            return ""
         with self.sketch_py.open() as fd:
             return fd.read()
 

--- a/pyp5js/sketch.py
+++ b/pyp5js/sketch.py
@@ -48,6 +48,12 @@ class Sketch:
         return self.sketch_py.exists()
 
     @property
+    def sketch_content(self):
+        with self.sketch_py.open() as fd:
+            return fd.read()
+
+
+    @property
     def has_all_files(self):
         return all([
             self.sketch_exists,

--- a/pyp5js/templates_renderers.py
+++ b/pyp5js/templates_renderers.py
@@ -12,16 +12,18 @@ def _template_from_file(filename, context):
     return template.render(context)
 
 
-def get_sketch_index_content(sketch):
+def get_sketch_index_content(sketch, template_file=None):
     """
-    Renders SKETCH_NAME/index.html to display the sketch visualization
+    Renders SKETCH_NAME/index.html to display the sketch visualization.
+    template can be a pathlib.Path object with a specified custom template path
     """
     context = {
         "sketch_name": sketch.sketch_name,
         "p5_js_url": sketch.urls.p5_js_url,
         "sketch_js_url":  sketch.urls.sketch_js_url,
+        "sketch_content": sketch.sketch_content,
     }
-    template_file = sketch.config.get_index_template()
+    template_file = template_file or sketch.config.get_index_template()
     return _template_from_file(template_file, context)
 
 

--- a/pyp5js/templates_renderers.py
+++ b/pyp5js/templates_renderers.py
@@ -29,12 +29,9 @@ def get_target_sketch_content(sketch):
     """
     Renders the content to be written in the temporary SKETCH_NAME/target_sketch.py file
     """
-    with sketch.sketch_py.open() as fd:
-        content = fd.read()
-
     context = {
         "sketch_name": sketch.sketch_name,
-        "sketch_content": content,
+        "sketch_content": sketch.sketch_content,
     }
     target_js_file = sketch.config.get_target_js_template()
     return _template_from_file(target_js_file, context)

--- a/pyp5js/templates_renderers.py
+++ b/pyp5js/templates_renderers.py
@@ -12,7 +12,7 @@ def _template_from_file(filename, context):
     return template.render(context)
 
 
-def get_sketch_index_content(sketch, template_file=None):
+def get_sketch_index_content(sketch):
     """
     Renders SKETCH_NAME/index.html to display the sketch visualization.
     template can be a pathlib.Path object with a specified custom template path
@@ -23,7 +23,7 @@ def get_sketch_index_content(sketch, template_file=None):
         "sketch_js_url":  sketch.urls.sketch_js_url,
         "sketch_content": sketch.sketch_content,
     }
-    template_file = template_file or sketch.config.get_index_template()
+    template_file = sketch.config.get_index_template()
     return _template_from_file(template_file, context)
 
 

--- a/pyp5js/tests/fixtures.py
+++ b/pyp5js/tests/fixtures.py
@@ -50,6 +50,19 @@ def pyodide_json_file():
         os.remove(filename)
 
 @fixture
+def custom_index_json_file():
+    try:
+        fd = NamedTemporaryFile(mode='w', delete=False)
+        data = {"interpreter": "transcrypt", "index_template": "docs/examples/transcrypt/index.html.template"}
+        json.dump(data, fd)
+        filename = fd.name
+        fd.seek(0)
+        fd.close()
+        yield filename
+    finally:
+        os.remove(filename)
+
+@fixture
 def transcrypt_config():
     return SketchConfig(interpreter=TRANSCRYPT_INTERPRETER)
 

--- a/pyp5js/tests/test_commands.py
+++ b/pyp5js/tests/test_commands.py
@@ -75,6 +75,7 @@ class TestNewSketchCommand(TestCase):
         assert self.sketch.p5js.exists()
         assert self.sketch.config_file.exists()
         assert self.sketch.config.interpreter == TRANSCRYPT_INTERPRETER
+        assert self.sketch.config.index_template == ""
 
     def test_create_pyodide_sketch(self):
         commands.new_sketch(self.sketch_name, interpreter=PYODIDE_INTERPRETER)

--- a/pyp5js/tests/test_commands.py
+++ b/pyp5js/tests/test_commands.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from pyp5js import commands
 from pyp5js.config import SKETCHBOOK_DIR, TRANSCRYPT_INTERPRETER, PYODIDE_INTERPRETER
+from pyp5js.config.fs import PYP5JS_FILES
 from pyp5js.exceptions import PythonSketchDoesNotExist, SketchDirAlreadyExistException, InvalidName
 from pyp5js.sketch import Sketch
 
@@ -90,3 +91,12 @@ class TestNewSketchCommand(TestCase):
 
         with pytest.raises(SketchDirAlreadyExistException):
             commands.new_sketch(self.sketch_name)
+
+    def test_create_sketch_with_custom_index(self):
+        template = PYP5JS_FILES.install.parent / "docs" / "examples" / "transcrypt" / "index.html.template"
+        commands.new_sketch(self.sketch_name, template_file=template)
+
+        assert self.sketch.index_html.exists()
+        with open(self.sketch.index_html) as fd:
+            content = fd.read()
+        assert "demoContainer" in content

--- a/pyp5js/tests/test_config/test_sketch.py
+++ b/pyp5js/tests/test_config/test_sketch.py
@@ -1,12 +1,13 @@
 import json
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from pyp5js.config import TRANSCRYPT_INTERPRETER, PYODIDE_INTERPRETER
 from pyp5js.config.sketch import SketchConfig
 from pyp5js.config.fs import PYP5JS_FILES
 
-from ..fixtures import transcrypt_json_file, pyodide_json_file, transcrypt_config, pyodide_config
+from ..fixtures import transcrypt_json_file, pyodide_json_file, transcrypt_config, pyodide_config, custom_index_json_file
 
 
 def test_init_transcrypt_sketch_config_from_json(transcrypt_json_file):
@@ -19,8 +20,8 @@ def test_init_pyodide_sketch_config_from_json(pyodide_json_file):
     assert config.interpreter == PYODIDE_INTERPRETER
 
 
-def test_write_sketch_interpreter_config(transcrypt_config):
-    config = transcrypt_config
+def test_write_sketch_interpreter_config(custom_index_json_file):
+    config = SketchConfig.from_json(custom_index_json_file)
     fd = NamedTemporaryFile(mode="w", delete=False)
     config.write(fd.name)
     fd.close()
@@ -28,24 +29,35 @@ def test_write_sketch_interpreter_config(transcrypt_config):
         data = json.load(fd)
 
     assert data["interpreter"] == TRANSCRYPT_INTERPRETER
+    assert config.index_template in data["index_template"]
     os.remove(fd.name)
+
 
 def test_get_transcrypt_index_template(transcrypt_config):
     template = transcrypt_config.get_index_template()
     assert PYP5JS_FILES.transcrypt_index_html == template
     assert template.exists()
 
+
 def test_get_pyodide_index_template(pyodide_config):
     template = pyodide_config.get_index_template()
     assert PYP5JS_FILES.pyodide_index_html == template
     assert template.exists()
+
 
 def test_get_transcrypt_target_js_template(transcrypt_config):
     template = transcrypt_config.get_target_js_template()
     assert PYP5JS_FILES.transcrypt_target_sketch_template == template
     assert template.exists()
 
+
 def test_get_pyodide_target_js_template(pyodide_config):
     template = pyodide_config.get_target_js_template()
     assert PYP5JS_FILES.pyodide_target_sketch_template == template
     assert template.exists()
+
+
+def test_get_custom_index_template(custom_index_json_file):
+    config = SketchConfig.from_json(custom_index_json_file)
+    template = config.get_index_template()
+    assert Path("docs/examples/transcrypt/index.html.template").absolute() == template

--- a/pyp5js/tests/test_config/test_sketch.py
+++ b/pyp5js/tests/test_config/test_sketch.py
@@ -29,8 +29,18 @@ def test_write_sketch_interpreter_config(custom_index_json_file):
         data = json.load(fd)
 
     assert data["interpreter"] == TRANSCRYPT_INTERPRETER
-    assert config.index_template in data["index_template"]
-    os.remove(fd.name)
+    assert str(config.index_template_path.resolve()) == data["index_template"]
+
+
+def test_wrrite_defaults():
+    config = SketchConfig(PYODIDE_INTERPRETER)
+    fd = NamedTemporaryFile(mode="w", delete=False)
+    config.write(fd.name)
+    fd.close()
+    with open(fd.name) as fd:
+        data = json.load(fd)
+
+    assert "" == data["index_template"]
 
 
 def test_get_transcrypt_index_template(transcrypt_config):

--- a/pyp5js/tests/test_templates_renderers.py
+++ b/pyp5js/tests/test_templates_renderers.py
@@ -18,22 +18,6 @@ def test_get_sketch_index_content(sketch):
     assert expected_content == renderers.get_sketch_index_content(sketch)
 
 
-def test_get_sketch_custom_index_content(sketch):
-    templates_path = PYP5JS_FILES.install.parent / "docs" / "examples" / "transcrypt"
-    assert templates_path.exists()
-    templates = Environment(loader=FileSystemLoader(str(templates_path)))
-    expected_template = templates.get_template('index.html.template')
-    expected_content = expected_template.render({
-        'sketch_name': sketch.sketch_name,
-        "p5_js_url": sketch.STATIC_NAME + "/p5.js",
-        "sketch_js_url": sketch.TARGET_NAME + "/target_sketch.js",
-        "sketch_content": sketch.sketch_content,
-    })
-
-    custom_index = templates_path / "index.html.template"
-    assert expected_content == renderers.get_sketch_index_content(sketch, template_file=custom_index)
-
-
 def test_get_target_sketch_content(sketch):
     with open(sketch.sketch_py, 'w') as fd:
         fd.write('content')

--- a/pyp5js/tests/test_templates_renderers.py
+++ b/pyp5js/tests/test_templates_renderers.py
@@ -1,8 +1,11 @@
+from jinja2 import Environment, FileSystemLoader
+
 from pyp5js import templates_renderers as renderers
 from pyp5js.sketch import Sketch
 from pyp5js.config.fs import PYP5JS_FILES
 
 from .fixtures import sketch
+
 
 def test_get_sketch_index_content(sketch):
     expected_template = renderers.templates.get_template('transcrypt/index.html')
@@ -13,6 +16,22 @@ def test_get_sketch_index_content(sketch):
     })
 
     assert expected_content == renderers.get_sketch_index_content(sketch)
+
+
+def test_get_sketch_custom_index_content(sketch):
+    templates_path = PYP5JS_FILES.install.parent / "docs" / "examples" / "transcrypt"
+    assert templates_path.exists()
+    templates = Environment(loader=FileSystemLoader(str(templates_path)))
+    expected_template = templates.get_template('index.html.template')
+    expected_content = expected_template.render({
+        'sketch_name': sketch.sketch_name,
+        "p5_js_url": sketch.STATIC_NAME + "/p5.js",
+        "sketch_js_url": sketch.TARGET_NAME + "/target_sketch.js",
+        "sketch_content": sketch.sketch_content,
+    })
+
+    custom_index = templates_path / "index.html.template"
+    assert expected_content == renderers.get_sketch_index_content(sketch, template_file=custom_index)
 
 
 def test_get_target_sketch_content(sketch):


### PR DESCRIPTION
This PR adds 2 new flags. Now the `new` command can be called with the flag `--template` that should be a path to an existing file. This file will be used as the input template to generate the final `index.html` for that sketch. 

The other flag is the `--refresh` to the `compile` command. This flag will make the compile command to update the `index.html` of the sketch after it finishes. This is extremely useful to regenerate examples' `index.html` from recent contributions.