### PR TITLE
Make code editor collapsible

### DIFF
--- a/pyp5js/http/templates/view_sketch.html
+++ b/pyp5js/http/templates/view_sketch.html
@@ -15,7 +15,7 @@
         }
 
         pre {
-            margin-right: 2em;
+          margin-right: 2em;
         }
 
         .text-editor-box {
@@ -77,7 +77,7 @@
             <div class="text-editor-box">
               <button id="collapseBtn" title="Collapse the code editor" type="button"
                 class="btn btn-primary bg-orange rounded py1 px2 pb3">
-                ⮜ Collapse</button>
+                Collapse</button>
               <div id="text-editor" class="text-editor">{{ py_code }}</div>
               <div id="sketch-buttons" class="clearfix">
                 {% if live_run %}
@@ -143,7 +143,7 @@
         collapseBtn.addEventListener("click", () => {
           const textEditorEl = document.getElementById("text-editor");
           textEditorEl.classList.toggle("hidden-editor");
-          collapseBtn.textContent = (collapseBtn.textContent.includes("Collapse")) ? "Expand ⮞" : "⮜ Collapse";
+          collapseBtn.textContent = (collapseBtn.textContent.includes("Collapse")) ? "Expand" : "Collapse";
         })
 
         clearBtn.addEventListener("click", () => {


### PR DESCRIPTION
- Adds a button on the top right of the local editor to make it so the text editor can be collapsed - This can make the page more user-friendly when dealing with larger sketches and split-screens.
- Closes #128

I had to change around some of the preexisting HTML and CSS so the page would better support the changes I was introducing without breaking the current layout, but as far as I've seen it hasn't broken anything.