### PR TITLE
Stop overwriting preload function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Development
 - Add `keyIsDown` event to Transcrypt mode - [PR #187](https://github.com/berinhard/pyp5js/pull/187)
 - Fix bug with multiple events calls - PR #187 too
 - Serve JS files if `--local` flag [PR #195](https://github.com/berinhard/pyp5js/pull/195)
+- Fix preload function bug in both modes - [PR #196](https://github.com/berinhard/pyp5js/pull/196)
 
 0.7.0
 -----

--- a/pyp5js/templates/pyodide/target_sketch.js.template
+++ b/pyp5js/templates/pyodide/target_sketch.js.template
@@ -374,9 +374,6 @@ def getURLPath(*args):
 def getURLParams(*args):
     return _P5_INSTANCE.getURLParams(*args)
 
-def preload(*args):
-    return _P5_INSTANCE.preload(*args)
-
 def remove(*args):
     return _P5_INSTANCE.remove(*args)
 
@@ -1565,10 +1562,11 @@ def global_p5_injection(p5_sketch):
     return decorator
 
 
-def start_p5(setup_func, draw_func, event_functions):
+def start_p5(preload_func, setup_func, draw_func, event_functions):
     """
     This is the entrypoint function. It accepts 2 parameters:
 
+    - preload_func: A Python preload callable
     - setup_func: a Python setup callable
     - draw_func: a Python draw callable
     - event_functions: a config dict for the event functions in the format:
@@ -1581,6 +1579,7 @@ def start_p5(setup_func, draw_func, event_functions):
         """
         Callback function called to configure new p5 instance
         """
+        p5_sketch.preload = global_p5_injection(p5_sketch)(preload_func)
         p5_sketch.setup = global_p5_injection(p5_sketch)(setup_func)
         p5_sketch.draw = global_p5_injection(p5_sketch)(draw_func)
 
@@ -1602,6 +1601,9 @@ def start_p5(setup_func, draw_func, event_functions):
 `;
 
 const placeholder = `
+def preload():
+    pass
+
 def setup():
     pass
 
@@ -1652,7 +1654,7 @@ event_functions = {
     "windowResized": windowResized,
 }
 
-start_p5(setup, draw, event_functions)
+start_p5(preload, setup, draw, event_functions)
 `;
 
 function runCode() {

--- a/pyp5js/templates/transcrypt/pyp5js.py
+++ b/pyp5js/templates/transcrypt/pyp5js.py
@@ -1189,10 +1189,11 @@ def global_p5_injection(p5_sketch):
     return decorator
 
 
-def start_p5(setup_func, draw_func, event_functions):
+def start_p5(preload_func, setup_func, draw_func, event_functions):
     """
     This is the entrypoint function. It accepts 2 parameters:
 
+    - preload_func: a Python preload callable
     - setup_func: a Python setup callable
     - draw_func: a Python draw callable
     - event_functions: a config dict for the event functions in the format:
@@ -1202,6 +1203,7 @@ def start_p5(setup_func, draw_func, event_functions):
     """
 
     def sketch_setup(p5_sketch):
+        p5_sketch.preload = global_p5_injection(p5_sketch)(preload_func)
         p5_sketch.setup = global_p5_injection(p5_sketch)(setup_func)
         p5_sketch.draw = global_p5_injection(p5_sketch)(draw_func)
 

--- a/pyp5js/templates/transcrypt/target_sketch.py.template
+++ b/pyp5js/templates/transcrypt/target_sketch.py.template
@@ -1,5 +1,8 @@
 from pyp5js import *
 
+def preload():
+    pass
+
 def setup():
     pass
 
@@ -50,4 +53,4 @@ event_functions = {
     "keyIsDown": keyIsDown,
 }
 
-start_p5(setup, draw, event_functions)
+start_p5(preload, setup, draw, event_functions)


### PR DESCRIPTION
- Fixes both pyodide and transcrypt modes so that the preload() function can work as intended.
- Closes #132 

I used the first code snippet in the issue to test it, seems to be working fine and as intended in both transcrypt and pyodide modes.