### PR TITLE
Change remove calls in the demo editor

### DIFF
--- a/docs/pyodide/index.html
+++ b/docs/pyodide/index.html
@@ -121,7 +121,7 @@ def draw():
     }
 
     $("#executeBtn").on("click", () => {runCode()});
-    $("#clearBtn").on("click", () => {$("#sketch-holder").html("")});
+    $("#clearBtn").on("click", () => { window.instance.remove(); });
     $("body").bind("keydown",keyDown);
   </script>
 

--- a/docs/pyodide/target/target_sketch.js
+++ b/docs/pyodide/target/target_sketch.js
@@ -1674,7 +1674,7 @@ function runCode() {
     ].join('\n');
 
     if (window.instance) {
-      window.instance.canvas.remove();
+      window.instance.remove();
     }
 
     console.log("Python execution output:");


### PR DESCRIPTION
- Instead of referring to window.instance.canvas, the "Run" button will reset the sketch by calling window.instance.remove().
- This makes it possible to completely terminate the sketch loop when calling "Run" and "Clear", avoiding memory issues from multiple sketches being created concurrently.
- Closes #198 

It's fine if this isn't an appropriate solution for the problem - since it's a bit of hack, but as far as I've tested it it seems to be working as intended. [You can test it here](https://jvfe.github.io/pyp5js/pyodide/).