### PR TITLE
Fire click event on run only once Pyodide loads

### DIFF
--- a/docs/pyodide/index.html
+++ b/docs/pyodide/index.html
@@ -65,7 +65,7 @@
         <!-- You sketch will go here! -->
       </div>
     </div>
-<div><p style="font-family: 'sans'; font-size:14px">If you execute the code but nothing is being rendered in the broswer, please open your browser's console to read the error traceback (usually you can do this by pressing F12 and clicking in the Console tab).</p></div>
+<div><p style="font-family: 'sans'; font-size:14px">If you execute the code but nothing is being rendered in the browser, please open your browser's console to read the error traceback (usually you can do this by pressing F12 and clicking in the Console tab).</p></div>
 <div><p style="background-color: #f6f8fa; font-family: 'sans'; font-size:14px"><a href="https://github.com/berinhard/pyp5js"><b>pyp5js</b></a> running on top of <a href="https://github.com/iodide-project/pyodide" target="_blank">pyodide</a></p></div>
   </body>
   <script type="text/javascript">
@@ -120,9 +120,22 @@ def draw():
       }
     }
 
-    $("#executeBtn").on("click", () => {runCode()});
-    $("#clearBtn").on("click", () => { window.instance.remove(); });
-    $("body").bind("keydown",keyDown);
+      $("#executeBtn").on("click", () => {
+        if (window.instance) {
+          runCode();
+        } else {
+          window.alert(
+            "Pyodide is still loading.\nPlease, wait a few seconds and try to run it again."
+          );
+        }
+      });
+      $("#clearBtn").on("click", () => {
+        if (window.instance) {
+          document.getElementById("sketch-holder").innerHTML = "";
+          window.instance.remove()
+        }
+      });
+      $("body").bind("keydown", keyDown);
   </script>
 
 


### PR DESCRIPTION
- Simple hack to avoid / fix #197 
- Expands the logic in the click events to check for the existence of the window.instance object before firing the event.
- Also fixes a typo I saw
- [Test it here](https://jvfe.github.io/pyp5js/pyodide/)
