### PR TITLE
Minor fixes to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   license:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Development
 -----------
 - Remove existing sketch after clearing/running it again [PR #199](https://github.com/berinhard/pyp5js/pull/199)
+- Add share button to demo editor [PR #205](https://github.com/berinhard/pyp5js/pull/205)
 
 0.7.1
 -----

--- a/docs/pyodide/styles.css
+++ b/docs/pyodide/styles.css
@@ -30,6 +30,8 @@ pre {
   float: left;
   margin: 0.5em 0;
   height: 600px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
 }
 
 .text-editor {


### PR DESCRIPTION
CI started to broken on MacOS builds because Python 3.6 is no longer distributed within the MacOS version used by Github Actions. This PR fixes this.