### PR TITLE
Add fullscreen sketch page to demo editor

### DIFF
--- a/docs/pyodide/afterBody.js
+++ b/docs/pyodide/afterBody.js
@@ -20,6 +20,7 @@ document.getElementById("id_py_code").innerHTML = initialSketch;
 document.addEventListener("DOMContentLoaded", function () {
   //// Buttons
   const shareBtn = document.getElementById("shareBtn");
+  const fullScreenBtn = document.getElementById("fullScreenBtn");
   const collapseBtn = document.getElementById("collapseBtn");
   const executeBtn = document.getElementById("executeBtn");
   const clearBtn = document.getElementById("clearBtn");
@@ -77,6 +78,10 @@ document.addEventListener("DOMContentLoaded", function () {
       }, 3000);
       runCode();
     }
+  });
+  fullScreenBtn.addEventListener("click", () => {
+    const fullScreenSketchUrl = createSketchUrl(true);
+    window.location = fullScreenSketchUrl;
   });
   collapseBtn.addEventListener("click", () => {
     const textEditorEl = document.getElementById("text-editor");

--- a/docs/pyodide/fullscreen.html
+++ b/docs/pyodide/fullscreen.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>pyp5js with Pyodide Demo</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.0.0/lib/p5.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.18.1/full/pyodide.js"></script>
+    <script src="share.js"></script>
+
+
+    <link rel="stylesheet" href="https://unpkg.com/basscss@7.1.1/css/basscss.min.css">
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+    <button id="returnBtn" title="Return to editor page" type="button"
+        class="btn btn-primary bg-black px1 mr2 ml2 mt2 caps h6">
+        Back to Editor</button>
+    <div id="sketch-holder" class="m2">
+        <!-- You sketch will go here! -->
+    </div>
+</body>
+<script src="target/target_sketch.js"></script>
+<script src="fullscreenAfterBody.js"></script>
+
+</html>

--- a/docs/pyodide/fullscreenAfterBody.js
+++ b/docs/pyodide/fullscreenAfterBody.js
@@ -1,5 +1,6 @@
 document.getElementById("returnBtn").addEventListener("click", () => {
   const currentSketchParam = new URLSearchParams(window.location.search);
-  const baseUrl = new URL(window.location.origin);
-  window.location = `${baseUrl}?${currentSketchParam}`;
+  const pathname = window.location.pathname.replace(/fullscreen.html/g, "");
+  const baseUrl = new URL(window.location.origin + pathname);
+  window.location = `${baseUrl}?sketch=${currentSketchParam.get("sketch")}`;
 });

--- a/docs/pyodide/fullscreenAfterBody.js
+++ b/docs/pyodide/fullscreenAfterBody.js
@@ -1,0 +1,5 @@
+document.getElementById("returnBtn").addEventListener("click", () => {
+  const currentSketchParam = new URLSearchParams(window.location.search);
+  const baseUrl = new URL(window.location.origin);
+  window.location = `${baseUrl}?${currentSketchParam}`;
+});

--- a/docs/pyodide/index.html
+++ b/docs/pyodide/index.html
@@ -22,7 +22,6 @@
     integrity="sha512-S4i/WUGRs22+8rjUVu4kBjfNuBNp8GVsgcK2lbaFdws4q6TF3Nd00LxqnHhuxS9iVDfNcUh0h6OxFUMP5DBD+g=="
     crossorigin="anonymous"></script>
   <script src="share.js"></script>
-  <script src="target/target_sketch.js" type="module"></script>
 
   <link rel="stylesheet" href="https://unpkg.com/basscss@7.1.1/css/basscss.min.css">
   <link rel="stylesheet" href="styles.css">
@@ -36,9 +35,14 @@
       <textarea class="display-none" id="id_py_code" name="py_code"></textarea>
       <div class="code-container">
         <div class="text-editor-box">
-          <button id="collapseBtn" title="Collapse the code editor" type="button"
-            class="btn btn-primary bg-orange rounded py1 px2 pb3">
-            Collapse</button>
+          <div class="right-buttons">
+            <button id="fullScreenBtn" title="See sketch in fullscreen" type="button"
+              class="btn btn-primary bg-purple rounded py1 px2 pb3 mr1">
+              Fullscreen</button>
+            <button id="collapseBtn" title="Collapse the code editor" type="button"
+              class="btn btn-primary bg-orange rounded py1 px2 pb3">
+              Collapse</button>
+          </div>
           <div id="text-editor" class="text-editor"></div>
           <div id="sketch-buttons" class="clearfix">
             <div class="left-buttons">
@@ -69,6 +73,7 @@
         href="https://github.com/iodide-project/pyodide" target="_blank">pyodide</a></p>
   </div>
 </body>
+<script src="target/target_sketch.js"></script>
 <script src="afterBody.js"></script>
 
 </html>

--- a/docs/pyodide/index.html.template
+++ b/docs/pyodide/index.html.template
@@ -22,7 +22,6 @@
     integrity="sha512-S4i/WUGRs22+8rjUVu4kBjfNuBNp8GVsgcK2lbaFdws4q6TF3Nd00LxqnHhuxS9iVDfNcUh0h6OxFUMP5DBD+g=="
     crossorigin="anonymous"></script>
   <script src="share.js"></script>
-  <script src="{{ sketch_js_url }}" type="module"></script>
 
   <link rel="stylesheet" href="https://unpkg.com/basscss@7.1.1/css/basscss.min.css">
   <link rel="stylesheet" href="styles.css">
@@ -36,9 +35,14 @@
       <textarea class="display-none" id="id_py_code" name="py_code"></textarea>
       <div class="code-container">
         <div class="text-editor-box">
-          <button id="collapseBtn" title="Collapse the code editor" type="button"
-            class="btn btn-primary bg-orange rounded py1 px2 pb3">
-            Collapse</button>
+          <div class="right-buttons">
+            <button id="fullScreenBtn" title="See sketch in fullscreen" type="button"
+              class="btn btn-primary bg-purple rounded py1 px2 pb3 mr1">
+              Fullscreen</button>
+            <button id="collapseBtn" title="Collapse the code editor" type="button"
+              class="btn btn-primary bg-orange rounded py1 px2 pb3">
+              Collapse</button>
+          </div>
           <div id="text-editor" class="text-editor"></div>
           <div id="sketch-buttons" class="clearfix">
             <div class="left-buttons">
@@ -69,6 +73,7 @@
         href="https://github.com/iodide-project/pyodide" target="_blank">pyodide</a></p>
   </div>
 </body>
+<script src="{{ sketch_js_url }}"></script>
 <script src="afterBody.js"></script>
 
 </html>

--- a/docs/pyodide/share.js
+++ b/docs/pyodide/share.js
@@ -1,5 +1,8 @@
-function createSketchUrl() {
-  const baseUrl = window.location.origin + window.location.pathname;
+function createSketchUrl(fullScreen = false) {
+  let baseUrl = window.location.origin + window.location.pathname;
+  if (fullScreen) {
+    baseUrl = baseUrl + "fullscreen.html";
+  }
   const userCode = editor.getSession().getValue();
 
   const encodedUserCode = btoa(encodeURIComponent(userCode));

--- a/docs/pyodide/styles.css
+++ b/docs/pyodide/styles.css
@@ -51,6 +51,11 @@ pre {
 .left-buttons {
   width: 100%;
 }
+.right-buttons {
+  width: 100%;
+  display: flex;
+  justify-content: right;
+}
 
 .hidden-editor {
   opacity: 0.2;

--- a/docs/pyodide/target/target_sketch.js
+++ b/docs/pyodide/target/target_sketch.js
@@ -1689,7 +1689,7 @@ async function main() {
       runCode();
     }
 
-    runCode();
+   window.runSketchCode(checkForSketch());
 };
 
 // async method


### PR DESCRIPTION
- Adds a page to the demo editor to see the sketch in fullscreen
- Refactor target_sketch in the demo editor so it runs sketchcode based
  on checkForSketch()
- Adds button to the demo editor to redirect to the fullscreen page
- Updates styles for main page

The reason for changing the way the main() function operates in
target_sketch is because it was the only way I found to execute the code
upon loading the page - therefore not requiring there to be a 'run'
button in the fullscreen page. Though there might be better solutions.
This change doesn't seem to break anything so I kept it as is.

[Here's a URL in my fork with the feature working as intended](https://jvfe.github.io/pyp5js/pyodide/fullscreen.html?sketch=ZGVmJTIwc2V0dXAoKSUzQSUwQSUyMCUyMCUyMCUyMGNyZWF0ZUNhbnZhcygyMDAlMkMlMjAyMDApJTBBJTBBZGVmJTIwZHJhdygpJTNBJTBBJTIwJTIwJTIwJTIwYmFja2dyb3VuZCgyMDApJTBBJTIwJTIwJTIwJTIwZGlhbWV0ZXIlMjAlM0QlMjBzaW4oZnJhbWVDb3VudCUyMCUyRiUyMDYwKSUyMColMjA1MCUyMCUyQiUyMDUwJTBBJTIwJTIwJTIwJTIwZmlsbCglMjJyZWQlMjIpJTBBJTIwJTIwJTIwJTIwZWxsaXBzZSgxMDAlMkMlMjAxMDAlMkMlMjBkaWFtZXRlciUyQyUyMGRpYW1ldGVyKSUwQSUyMCUyMCUyMCUyMA%3D%3D)

- Addresses #210

See if this is what you had in mind @villares 
