### PR TITLE
Fix import errors - Change dependency versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 
-black==19.3b0
-ipython==7.16.3
-pytest==4.5.0
-tox==3.10.0
+black==22.10.0
+ipython==8.5.0
+pytest==7.1.3
+tox==3.26.0
 pytest-env==0.6.2
-Flask-Testing==0.8.0
-blinker==1.4
-pyaml==20.4.0
-wheel==0.37.0
-twine==3.4.2
+Flask-Testing==0.8.1
+blinker==1.5
+pyaml==21.10.1
+wheel==0.37.1
+twine==4.0.1

--- a/pyp5js/http/web_app.py
+++ b/pyp5js/http/web_app.py
@@ -17,14 +17,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 import ast
 import os
+
 from flask import Flask, render_template, request, send_from_directory
-from slugify import slugify
-
 from pyp5js import commands
-from pyp5js.config import SKETCHBOOK_DIR, PYODIDE_INTERPRETER, AVAILABLE_INTERPRETERS, TRANSCRYPT_INTERPRETER
-from pyp5js.exceptions import PythonSketchDoesNotExist, SketchDirAlreadyExistException
+from pyp5js.config import (AVAILABLE_INTERPRETERS, PYODIDE_INTERPRETER,
+                           SKETCHBOOK_DIR, TRANSCRYPT_INTERPRETER)
+from pyp5js.exceptions import (PythonSketchDoesNotExist,
+                               SketchDirAlreadyExistException)
 from pyp5js.sketch import Sketch
-
+from slugify import slugify
 
 app = Flask(__name__)
 SUPPORTED_IMAGE_FILE_SUFFIXES = (".gif", ".jpg", ".png")
@@ -127,7 +128,7 @@ def _serve_static(static_dir, static_path):
         # User tried something not allowed (as "/root/something" or "../xxx")
         return '', 403
 
-    resp = send_from_directory(static_dir.absolute(), static_path, add_etags=False, cache_timeout=0)
+    resp = send_from_directory(static_dir.absolute(), static_path, etag=False, max_age=0)
 
     if os.name == 'nt' and static_path.lower().endswith('.js'):
         js_content = resp.headers['Content-Type'].replace('text/plain', 'application/javascript')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-Click==7.1.1
-Jinja2==2.11.3
+Click==8.0.1
+Jinja2==3.1.2
 Transcrypt==3.9.0
-cprint==1.1
-gunicorn==19.9.0
-watchdog==0.9.0
-python-decouple==3.1
-Flask==1.1.2
-python-slugify==3.0.4
+cprint==1.2.2
+gunicorn==20.1.0
+watchdog==2.1.9
+python-decouple==3.6
+Flask==2.2.2
+python-slugify==6.1.2


### PR DESCRIPTION
This changes the versions of the dependencies, since the previous ones were throwing errors when you tried to install pyp5js with python>=3.8. 
I also had to change a few keyword arguments in send_from_directory since the ones that were being used were deprecated and are no longer present in the most recent version.

Some tests are still failing and I haven't figured out why yet. Not very familiar with flask_testing - so this is worth looking into. Nevertheless, I think the software is working properly.

- fix: Update versions in requirements
- fix: Update send_from_directory keyword args
- Closes #212 (I think)
