### PR TITLE
Add --version flag to pyp5js CLI interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Development
 -----------
+- Add `--version` parameter to the command line interface [PR #223](https://github.com/berinhard/pyp5js/pull/223)
 
 0.7.3
 -----

--- a/pyp5js/cli.py
+++ b/pyp5js/cli.py
@@ -27,6 +27,7 @@ from pyp5js.config import SKETCHBOOK_DIR, AVAILABLE_INTERPRETERS, PYODIDE_INTERP
 
 
 @click.group()
+@click.version_option(package_name="pyp5js", prog_name="pyp5js")
 def command_line_entrypoint():
     """
     pyp5js is a command line tool to conver Python 3 code to p5.js.


### PR DESCRIPTION
Fixes #202 by using click's version default option. Now, the user will be able to print the project version with:

```
$ pyp5js --version
pyp5js, version 0.7.3
```